### PR TITLE
Adding support to NOT REGEXP_QUERY

### DIFF
--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/MethodQueryIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/MethodQueryIT.java
@@ -91,6 +91,26 @@ public class MethodQueryIT extends SQLIntegTestCase {
                 "{\"filter\":{\"match\":{\"address\":{\"query\":\"Street\"")));
   }
 
+  @Test
+  public void regexpQueryTest() throws IOException {
+    final String result = explainQuery(String.format(Locale.ROOT,
+        "SELECT * FROM %s WHERE address=REGEXP_QUERY('.*')",
+        TestsConstants.TEST_INDEX_ACCOUNT));
+    Assert.assertThat(result,
+        containsString("{\"bool\":{\"must\":[{\"regexp\":"
+            + "{\"address\":{\"value\":\".*\",\"flags_value\":255,\"max_determinized_states\":10000,\"boost\":1.0}}}"));
+  }
+
+  @Test
+  public void negativeRegexpQueryTest() throws IOException {
+    final String result = explainQuery(String.format(Locale.ROOT,
+        "SELECT * FROM %s WHERE NOT(address=REGEXP_QUERY('.*'))",
+        TestsConstants.TEST_INDEX_ACCOUNT));
+    Assert.assertThat(result,
+        containsString("{\"bool\":{\"must_not\":[{\"regexp\":"
+            + "{\"address\":{\"value\":\".*\",\"flags_value\":255,\"max_determinized_states\":10000,\"boost\":1.0}}}"));
+  }
+
   /**
    * wildcardQuery 是用通配符的方式查找某个term 　比如例子中 l*e means leae ltae ....
    * "wildcard": { "address" : { "wildcard" : "l*e" } }

--- a/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/QueryIT.java
+++ b/integ-test/src/test/java/com/amazon/opendistroforelasticsearch/sql/legacy/QueryIT.java
@@ -483,6 +483,22 @@ public class QueryIT extends SQLIntegTestCase {
   }
 
   @Test
+  public void negativeRegexQueryTest() throws IOException {
+    JSONObject response = executeQuery(
+        String.format(Locale.ROOT, "SELECT * " +
+                "FROM %s " +
+                "WHERE NOT(dog_name = REGEXP_QUERY('sn.*', 'INTERSECTION|COMPLEMENT|EMPTY', 10000))",
+            TestsConstants.TEST_INDEX_DOG));
+
+    JSONArray hits = getHits(response);
+    Assert.assertEquals(1, hits.length());
+
+    JSONObject hitSource = getSource(hits.getJSONObject(0));
+    Assert.assertNotEquals("snoopy", hitSource.getString("dog_name"));
+    Assert.assertEquals("rex", hitSource.getString("dog_name"));
+  }
+
+  @Test
   public void doubleNotTest() throws IOException {
     JSONObject response1 = executeQuery(
         String.format(Locale.ROOT,

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/domain/Condition.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/domain/Condition.java
@@ -63,7 +63,8 @@ public class Condition extends Where {
         CHILDREN_COMPLEX,
         SCRIPT,
         NIN_TERMS,
-        NTERM;
+        NTERM,
+        NREGEXP;
 
         public static Map<String, OPERATOR> methodNameToOpear;
 
@@ -136,6 +137,7 @@ public class Condition extends Where {
             negatives.put(IN, NIN);
             negatives.put(BETWEEN, NBETWEEN);
             negatives.put(NESTED_COMPLEX, NOT_EXISTS_NESTED_COMPLEX);
+            negatives.put(REGEXP, NREGEXP);
         }
 
         static {

--- a/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/query/maker/Maker.java
+++ b/legacy/src/main/java/com/amazon/opendistroforelasticsearch/sql/legacy/query/maker/Maker.java
@@ -95,7 +95,7 @@ public abstract class Maker {
     private static final Set<Condition.OPERATOR> NOT_OPERATOR_SET = ImmutableSet.of(
             Condition.OPERATOR.N, Condition.OPERATOR.NIN, Condition.OPERATOR.ISN, Condition.OPERATOR.NBETWEEN,
             Condition.OPERATOR.NLIKE, Condition.OPERATOR.NIN_TERMS, Condition.OPERATOR.NTERM,
-            Condition.OPERATOR.NOT_EXISTS_NESTED_COMPLEX
+            Condition.OPERATOR.NOT_EXISTS_NESTED_COMPLEX, Condition.OPERATOR.NREGEXP
     );
 
     protected Maker(Boolean isQuery) {
@@ -217,6 +217,7 @@ public abstract class Maker {
                 toXContent = QueryBuilders.wildcardQuery(name, queryStr);
                 break;
             case REGEXP:
+            case NREGEXP:
                 Object[] values = (Object[]) value;
                 RegexpQueryBuilder regexpQuery = QueryBuilders.regexpQuery(name, values[0].toString());
                 if (1 < values.length) {


### PR DESCRIPTION
Adding support to NOT REGEXP_QUERY, which is currently failing when run with "Negative operator [REGEXP] is not supported."

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.